### PR TITLE
Add Bluetooth Classic support to the Python CLI

### DIFF
--- a/fichero/cli.py
+++ b/fichero/cli.py
@@ -19,6 +19,7 @@ from fichero.printer import (
     PrinterError,
     PrinterNotReady,
     connect,
+    connect_classic
 )
 
 
@@ -144,9 +145,11 @@ async def cmd_set(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
+    global connect
     parser = argparse.ArgumentParser(description="Fichero D11s Label Printer")
     parser.add_argument("--address", default=os.environ.get("FICHERO_ADDR"),
-                        help="BLE address (skip scanning, or set FICHERO_ADDR)")
+                        help="BLE address (skip scanning, or set FICHERO_ADDR) or COM port in Bluetooth Classic mode")
+    parser.add_argument("--classic", help="Use Bluetooth Classic", action="store_true")
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_info = sub.add_parser("info", help="Show device info")
@@ -179,6 +182,8 @@ def main() -> None:
     p_set.set_defaults(func=cmd_set)
 
     args = parser.parse_args()
+    if args.classic:
+        connect = connect_classic
     try:
         asyncio.run(args.func(args))
     except PrinterError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "bleak",
     "pillow",
+    "pyserial"
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -77,12 +77,14 @@ source = { editable = "." }
 dependencies = [
     { name = "bleak" },
     { name = "pillow" },
+    { name = "pyserial" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "bleak" },
     { name = "pillow" },
+    { name = "pyserial" },
 ]
 
 [[package]]
@@ -252,6 +254,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/40/49b1c1702114ee972678597393320d7b33f477e9d24f2a62f93d77f23dfb/pyobjc_framework_libdispatch-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e9f49517e253716e40a0009412151f527005eec0b9a2311ac63ecac1bdf02332", size = 15938, upload-time = "2025-11-14T09:53:03.461Z" },
     { url = "https://files.pythonhosted.org/packages/59/d8/7d60a70fc1a546c6cb482fe0595cb4bd1368d75c48d49e76d0bc6c0a2d0f/pyobjc_framework_libdispatch-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0ebfd9e4446ab6528126bff25cfb09e4213ddf992b3208978911cfd3152e45f5", size = 15693, upload-time = "2025-11-14T09:53:05.531Z" },
     { url = "https://files.pythonhosted.org/packages/99/32/15e08a0c4bb536303e1568e2ba5cae1ce39a2e026a03aea46173af4c7a2d/pyobjc_framework_libdispatch-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:23fc9915cba328216b6a736c7a48438a16213f16dfb467f69506300b95938cc7", size = 15976, upload-time = "2025-11-14T09:53:07.936Z" },
+]
+
+[[package]]
+name = "pyserial"
+version = "3.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/7d/ae3f0a63f41e4d2f6cb66a5b57197850f919f59e558159a4dd3a818f5082/pyserial-3.5.tar.gz", hash = "sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb", size = 159125, upload-time = "2020-11-23T03:59:15.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl", hash = "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0", size = 90585, upload-time = "2020-11-23T03:59:13.41Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This allows using Bluetooth Classic to connect to the printer instead of BLE, which is more reliable on older Bluetooth adapters and Linux systems.

To use it, connect to the printer using your operating system's Bluetooth menu and get its serial port name, then provide it like so: `fichero --classic --address /dev/rfcomm0 info`