### PR TITLE
check chrome and reply informative

### DIFF
--- a/web/src/components/MainPage.svelte
+++ b/web/src/components/MainPage.svelte
@@ -48,7 +48,7 @@
   </div>
   <div>
     {#if appCommit}
-      <a class="text-secondary" href="https://github.com/mohamedha/fichero-printer/commit/{appCommit}">
+      <a class="text-secondary" href="https://github.com/0xMH/fichero-printer/commit/{appCommit}">
         {appCommit.slice(0, 6)}
       </a>
     {/if}
@@ -56,7 +56,7 @@
     {buildDate}
   </div>
   <div>
-    <a class="text-secondary" href="https://github.com/mohamedha/fichero-printer">{$tr("main.code")}</a>
+    <a class="text-secondary" href="https://github.com/0xMH/fichero-printer">{$tr("main.code")}</a>
     <button class="text-secondary btn btn-link p-0" onclick={() => debugStuffShow = true}>
       <MdIcon icon="bug_report" />
     </button>

--- a/web/src/components/basic/BrowserWarning.svelte
+++ b/web/src/components/basic/BrowserWarning.svelte
@@ -2,10 +2,11 @@
   import { Utils } from "$/lib/fichero";
   import { tr } from "$/utils/i18n";
   import MdIcon from "$/components/basic/MdIcon.svelte";
-  import { detectAntiFingerprinting } from "$/utils/browsers";
+  import { detectAntiFingerprinting, detectChromeBased } from "$/utils/browsers";
   let caps = Utils.getAvailableTransports();
 
   let antiFingerprinting = detectAntiFingerprinting();
+  let isChromeBased = detectChromeBased();
   let isMobile = typeof navigator !== "undefined" && /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 </script>
 
@@ -18,6 +19,11 @@
       <div>
         {$tr("browser_warning.lines.first")}
       </div>
+      {#if isChromeBased}
+        <div style="margin-top: 10px; font-size: 0.9em;">
+          {$tr("browser_warning.lines.third")}
+        </div>
+      {/if}
       <div>
         {$tr("browser_warning.lines.second")}
       </div>

--- a/web/src/locale/dicts/ar.json
+++ b/web/src/locale/dicts/ar.json
@@ -2,6 +2,7 @@
     "lang.name": "العربية",
     "browser_warning.fingerprinting": "تنبيه! يبدو أن متصفحك يُشوّه الصورة للحماية من التعقب. يُرجى تعطيل هذه الحماية، لأنها قد تُسبب تشوهات في الملصقات.",
     "browser_warning.lines.first": "لا لا! متصفحك لا يدعم البلوتوث والاتصالات التسلسلية.",
+    "browser_warning.lines.third": "أو تحقق من chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "على أي حال، لا زال بإمكانك رسم ملصقات.",
     "connector.bluetooth": "بلوتوث",
     "connector.disconnect.heartbeat": "انقطع الاتصال (الطابعة لا تستجيب)",

--- a/web/src/locale/dicts/cs.json
+++ b/web/src/locale/dicts/cs.json
@@ -1,6 +1,7 @@
 {
     "lang.name": "Čeština",
     "browser_warning.lines.first": "Aj, váš prohlížeč nepodporuje bluetooth a sériovou komunikaci",
+    "browser_warning.lines.third": "Nebo zkontrolujte chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "I tak můžete upravovat štítky.",
     "connector.bluetooth": "Bluetooth",
     "connector.disconnect.heartbeat": "Odpojeno (tiskárna neodpovídá)",

--- a/web/src/locale/dicts/de.json
+++ b/web/src/locale/dicts/de.json
@@ -1,6 +1,7 @@
 {
     "lang.name": "Deutsch",
     "browser_warning.lines.first": "Oh nein, Dein Browser unterstützt kein Bluetooth und keine serielle Schnittstelle",
+    "browser_warning.lines.third": "Oder prüfe chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "Du kannst trotzdem Etiketten erstellen.",
     "connector.bluetooth": "Bluetooth",
     "connector.disconnect.heartbeat": "Getrennt (Drucker reagiert nicht)",

--- a/web/src/locale/dicts/en.json
+++ b/web/src/locale/dicts/en.json
@@ -2,6 +2,7 @@
     "lang.name": "English",
     "browser_warning.fingerprinting": "Whoa! It looks like your browser is distorting the canvas to protect against fingerprinting. Please disable this protection, as it can cause artifacts on labels.",
     "browser_warning.lines.first": "Your browser does not support Web Bluetooth. Use Chrome, Edge, or Opera to connect to your printer.",
+    "browser_warning.lines.third": "Or check chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "You can still design labels without connecting.",
     "connector.bluetooth": "Bluetooth",
     "connector.disconnect.heartbeat": "Disconnected (printer does not respond)",

--- a/web/src/locale/dicts/es.json
+++ b/web/src/locale/dicts/es.json
@@ -2,6 +2,7 @@
     "lang.name": "Español",
     "browser_warning.fingerprinting": "¡Vaya! Parece que tu navegador está distorsionando el lienzo para protegerte del fingerprinting. Por favor, desactiva esta protección, ya que puede provocar artefactos en las etiquetas.",
     "browser_warning.lines.first": "Oh no, tu navegador no admite comunicaciones Bluetooth ni serie",
+    "browser_warning.lines.third": "O revisa chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "En cualquier caso, aún puedes dibujar etiquetas.",
     "connector.bluetooth": "Bluetooth",
     "connector.disconnect.heartbeat": "Desconectado (la impresora no responde)",

--- a/web/src/locale/dicts/fr.json
+++ b/web/src/locale/dicts/fr.json
@@ -1,6 +1,7 @@
 {
     "lang.name": "Français",
     "browser_warning.lines.first": "Oh non, votre navigateur ne prend pas en charge les communications Bluetooth et série",
+    "browser_warning.lines.third": "Ou consultez chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "Quoi qu'il en soit, vous pouvez toujours dessiner des étiquettes.",
     "connector.bluetooth": "Bluetooth",
     "connector.disconnect.heartbeat": "Déconnecté (l'imprimante ne répond pas)",

--- a/web/src/locale/dicts/hi.json
+++ b/web/src/locale/dicts/hi.json
@@ -2,6 +2,7 @@
     "lang.name": "हिंदी",
     "browser_warning.fingerprinting": "अरे! ऐसा लगता है कि आपका ब्राउज़र फ़िंगरप्रिंटिंग से सुरक्षा के लिए कैनवास को विकृत कर रहा है। कृपया इस सुरक्षा को अक्षम करें, क्योंकि इससे लेबल पर त्रुटियाँ या विकृति उत्पन्न हो सकती हैं।",
     "browser_warning.lines.first": "ओह नहीं, आपका ब्राउज़र ब्लूटूथ और सीरियल संचार का समर्थन नहीं करता है",
+    "browser_warning.lines.third": "या chrome://flags/#enable-experimental-web-platform-features देखें",
     "browser_warning.lines.second": "इसके बावजूद, आप अभी भी लेबल बना सकते हैं।",
     "connector.bluetooth": "ब्लूटूथ",
     "connector.disconnect.heartbeat": "डिस्कनेक्टेड (प्रिंटर प्रतिक्रिया नहीं दे रहा है)",

--- a/web/src/locale/dicts/hr.json
+++ b/web/src/locale/dicts/hr.json
@@ -2,6 +2,7 @@
     "lang.name": "Hrvatski",
     "browser_warning.fingerprinting": "Opa! Izgleda da vaš preglednik iskrivljuje platno da bi vas zaštitio od fingerprintinga. Molimo onemogućite ovu zaštitu jer može uzrokovati artefakte na etiketama.",
     "browser_warning.lines.first": "O, ne! Vaš preglednik ne podržava bluetooth i serijsku komunikaciju",
+    "browser_warning.lines.third": "Ili provjerite chrome://flags/#enable-experimental-web-platform-features",
     "connector.bluetooth": "Bluetooth",
     "connector.serial": "Serijski (USB)",
     "editor.clear": "Očisti platno",

--- a/web/src/locale/dicts/hu.json
+++ b/web/src/locale/dicts/hu.json
@@ -2,6 +2,7 @@
     "lang.name": "Magyar",
     "browser_warning.fingerprinting": "Whoa! It looks like your browser is distorting the canvas to protect against fingerprinting. Please disable this protection, as it can cause artifacts on labels.",
     "browser_warning.lines.first": "Úgy tűnik, hogy ez a böngésző nem támogatja egyik kommunikációs protokollt sem",
+    "browser_warning.lines.third": "Vagy nézze meg: chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "Szerkesztésre továbbra is van lehetőség.",
     "connector.bluetooth": "Bluetooth",
     "connector.disconnect.heartbeat": "Kapcsolat bontva (nyomtató nem válaszol)",

--- a/web/src/locale/dicts/it.json
+++ b/web/src/locale/dicts/it.json
@@ -1,6 +1,7 @@
 {
     "lang.name": "Italiano",
     "browser_warning.lines.first": "Oh no, il tuo browser non supporta le comunicazioni Bluetooth e seriali",
+    "browser_warning.lines.third": "Oppure verifica chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "Comunque, puoi disegnare etichette.",
     "connector.bluetooth": "Bluetooth",
     "connector.disconnect.heartbeat": "Disconnesso (la stampante non risponde)",

--- a/web/src/locale/dicts/ko_KR.json
+++ b/web/src/locale/dicts/ko_KR.json
@@ -2,6 +2,7 @@
     "lang.name": "한국어",
     "browser_warning.fingerprinting": "브라우저가 지문 추적을 방지하기 위해 캔버스를 왜곡하고 있는 것 같습니다. 이 보호 기능을 해제하세요. 그렇지 않으면 라벨에 이상한 자국이 생길 수 있습니다.",
     "browser_warning.lines.first": "앗, 브라우저가 블루투스 및 USB(시리얼) 통신을 지원하지 않습니다.",
+    "browser_warning.lines.third": "또는 chrome://flags/#enable-experimental-web-platform-features 에서 확인하세요",
     "browser_warning.lines.second": "어쨌든 라벨을 계속 그릴 수 있습니다.",
     "connector.bluetooth": "블루투스",
     "connector.disconnect.heartbeat": "연결 끊김 (프린터가 응답하지 않음)",

--- a/web/src/locale/dicts/mr.json
+++ b/web/src/locale/dicts/mr.json
@@ -2,6 +2,7 @@
     "lang.name": "मराठी",
     "browser_warning.fingerprinting": "अरे! असे दिसत आहे की तुमचा ब्राउझर फिंगरप्रिंटिंगपासून संरक्षण करण्यासाठी कॅनव्हासमध्ये बदल करत आहे. कृपया हे संरक्षण बंद करा, कारण यामुळे लेबलवर त्रुटी निर्माण होऊ शकतात.",
     "browser_warning.lines.first": "अरे नाही, तुमचा ब्राउझर ब्लूटूथ आणि सिरीयल संप्रेषणाला समर्थन देत नाही",
+    "browser_warning.lines.third": "किंवा chrome://flags/#enable-experimental-web-platform-features तपासा",
     "browser_warning.lines.second": "तरीही, तुम्ही लेबल तयार करू शकता.",
     "connector.bluetooth": "ब्लूटूथ",
     "connector.disconnect.heartbeat": "कनेक्शन तुटले आहे (प्रिंटर प्रतिसाद देत नाही)",

--- a/web/src/locale/dicts/pl.json
+++ b/web/src/locale/dicts/pl.json
@@ -1,6 +1,7 @@
 {
     "lang.name": "Polski",
     "browser_warning.lines.first": "O nie, Twoja przeglądarka nie obsługuje komunikacji Bluetooth i szeregowej",
+    "browser_warning.lines.third": "Lub sprawdź chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "Mimo tego możesz nadal projektować etykiety.",
     "connector.bluetooth": "Bluetooth",
     "connector.disconnect.heartbeat": "Rozłączono (drukarka nie odpowiada)",

--- a/web/src/locale/dicts/pt_BR.json
+++ b/web/src/locale/dicts/pt_BR.json
@@ -1,6 +1,7 @@
 {
     "lang.name": "Português",
     "browser_warning.lines.first": "Ah não, seu navegador não suporta comunicações bluetooth e seriais",
+    "browser_warning.lines.third": "Ou verifique chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "Mesmo assim, você ainda pode desenhar etiquetas.",
     "connector.bluetooth": "Bluetooth",
     "connector.disconnect.heartbeat": "Desconectado (impressora não responde)",

--- a/web/src/locale/dicts/ru.json
+++ b/web/src/locale/dicts/ru.json
@@ -2,6 +2,7 @@
     "lang.name": "Русский",
     "browser_warning.fingerprinting": "Воу! Похоже, что ваш браузер искажает холст для борьбы с цифровыми отпечатками. Отключите эту защиту, так как она может вызвать артефакты на этикетках.",
     "browser_warning.lines.first": "О нет, ваш браузер не поддерживает Bluetooth и последовательный порт",
+    "browser_warning.lines.third": "Или откройте chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "В любом случае, вы можете рисовать этикетки.",
     "connector.bluetooth": "Bluetooth",
     "connector.disconnect.heartbeat": "Отключено (принтер не отвечает)",

--- a/web/src/locale/dicts/tr.json
+++ b/web/src/locale/dicts/tr.json
@@ -2,6 +2,7 @@
     "lang.name": "Türkçe",
     "browser_warning.fingerprinting": "Dikkat! Tarayıcınız parmak izi koruması için tuvali bozuyor gibi görünüyor. Lütfen bu korumayı devre dışı bırakın, etiketlerde bozulmalara neden olabilir.",
     "browser_warning.lines.first": "Maalesef tarayıcınız Bluetooth ve seri iletişimi desteklemiyor",
+    "browser_warning.lines.third": "Veya chrome://flags/#enable-experimental-web-platform-features adresine bakın",
     "browser_warning.lines.second": "Yine de etiket tasarlayabilirsiniz.",
     "connector.bluetooth": "Bluetooth",
     "connector.disconnect.heartbeat": "Bağlantı kesildi (yazıcı yanıt vermiyor)",

--- a/web/src/locale/dicts/zh_cn.json
+++ b/web/src/locale/dicts/zh_cn.json
@@ -1,6 +1,7 @@
 {
     "lang.name": "简体中文",
     "browser_warning.lines.first": "哦豁，你的浏览器貌似不支持蓝牙和串口通讯",
+    "browser_warning.lines.third": "或查看 chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "但是你依然可以使用标签编辑功能",
     "connector.bluetooth": "蓝牙",
     "connector.disconnect.heartbeat": "已断开（打印机无响应）",

--- a/web/src/locale/dicts/zh_tw.json
+++ b/web/src/locale/dicts/zh_tw.json
@@ -2,6 +2,7 @@
     "lang.name": "繁體中文",
     "browser_warning.fingerprinting": "哇！看起來您的瀏覽器正在扭曲畫布以防止指紋識別。請停用此保護，因為它可能會在標籤上造成瑕疵。",
     "browser_warning.lines.first": "哎呀，您的瀏覽器似乎不支援藍牙和序列埠通訊",
+    "browser_warning.lines.third": "或查看 chrome://flags/#enable-experimental-web-platform-features",
     "browser_warning.lines.second": "但是您仍然可以使用標籤編輯功能",
     "connector.bluetooth": "藍牙",
     "connector.disconnect.heartbeat": "已中斷連線（印表機無回應）",

--- a/web/src/utils/browsers.ts
+++ b/web/src/utils/browsers.ts
@@ -1,3 +1,10 @@
+/** Check if browser is Chrome-based (Chrome, Chromium, Edge, Opera, Brave, etc.) */
+export const detectChromeBased = () => {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent.toLowerCase();
+  return /chrome|chromium|edg|opr|brave/i.test(ua) && !/firefox/i.test(ua);
+};
+
 /** Check if browser makes some modifications to canvas when reading */
 export const detectAntiFingerprinting = () => {
   const size = 32;


### PR DESCRIPTION
Thanks for your work!


When trying to use webbluetooth, not all chrome variants allow it from the defaults, even though they're capable.
I ran onto this issue using my linux machines using different browsers, so I assume this can be useful information for others as well.
So my modification shows a hint when it detects a chrome browser while not able to start the bluetooth plugin, in that case it might be due to Experimental Features not being enabled.

I did do translations using AI and have no clue what's written there, and also got nofications on the hr.json missing a translation for browser_warning.lines.second.
Again, as I have no clue what the first line states. It might be correct and complete, but I'll leave that for you to decide.

I also update links in footer as they were referencing to a non-existing github repo (I assume the one you didn't want to get public)
